### PR TITLE
Add maze debug printing

### DIFF
--- a/codexlog.md
+++ b/codexlog.md
@@ -1,0 +1,10 @@
+# Codex Change Log
+
+## 2025-07-13
+- Added maze generation module and initialized maze in main script.
+- Ensured script files end with a newline.
+
+### Later
+- Implemented `debug_print` in `maze.lua` to visualize the maze in the console.
+- Updated `main.script` to call the new debug method after generation.
+

--- a/main/main.script
+++ b/main/main.script
@@ -1,10 +1,16 @@
+local Maze = require "main.maze"
+
 function init(self)
-	msg.post(".", "acquire_input_focus")
-	msg.post("@render:", "use_fixed_fit_projection", { near = -1, far = 1 })
+    msg.post(".", "acquire_input_focus")
+    msg.post("@render:", "use_fixed_fit_projection", { near = -1, far = 1 })
+    self.maze = Maze.new(50, 50, 64, 64)
+    self.maze:generate()
+    print("Maze generated")
+    self.maze:debug_print()
 end
 
 function on_input(self, action_id, action)
-	if action_id == hash("touch") and action.pressed then
-		print("Touch!")
-	end
+    if action_id == hash("touch") and action.pressed then
+        print("Touch!")
+    end
 end

--- a/main/maze.lua
+++ b/main/maze.lua
@@ -1,0 +1,119 @@
+-- maze.lua
+-- Provides functions to create a base grid and generate a maze
+
+local Maze = {}
+
+-- Create a new maze object
+-- width, height: dimensions of the maze to generate
+-- base_width, base_height: dimensions of the underlying grid
+function Maze.new(width, height, base_width, base_height)
+    base_width = base_width or width
+    base_height = base_height or height
+    local grid = {}
+    for y = 1, base_height do
+        grid[y] = {}
+        for x = 1, base_width do
+            grid[y][x] = {
+                block_top = true,
+                block_left = true,
+                disable_clear_wall = false
+            }
+        end
+    end
+    local self = {
+        width = width,
+        height = height,
+        base_width = base_width,
+        base_height = base_height,
+        grid = grid
+    }
+    return setmetatable(self, { __index = Maze })
+end
+
+-- Helper to check bounds
+local function in_bounds(x, y, w, h)
+    return x >= 1 and x <= w and y >= 1 and y <= h
+end
+
+-- Carve the maze using a depth-first search (recursive backtracker)
+function Maze:generate()
+    local visited = {}
+    for y = 1, self.height do
+        visited[y] = {}
+    end
+
+    local stack = {}
+    table.insert(stack, { x = 1, y = 1 })
+    visited[1][1] = true
+
+    local function neighbors(x, y)
+        local list = {}
+        if in_bounds(x, y - 1, self.width, self.height) and not visited[y - 1][x] then
+            table.insert(list, { x = x, y = y - 1, dir = "up" })
+        end
+        if in_bounds(x - 1, y, self.width, self.height) and not visited[y][x - 1] then
+            table.insert(list, { x = x - 1, y = y, dir = "left" })
+        end
+        if in_bounds(x + 1, y, self.width, self.height) and not visited[y][x + 1] then
+            table.insert(list, { x = x + 1, y = y, dir = "right" })
+        end
+        if in_bounds(x, y + 1, self.width, self.height) and not visited[y + 1][x] then
+            table.insert(list, { x = x, y = y + 1, dir = "down" })
+        end
+        return list
+    end
+
+    math.randomseed(os.time())
+    while #stack > 0 do
+        local current = stack[#stack]
+        local nbs = neighbors(current.x, current.y)
+        if #nbs > 0 then
+            local next = nbs[math.random(#nbs)]
+            -- remove wall between current and next
+            if next.dir == "up" then
+                self.grid[current.y][current.x].block_top = false
+            elseif next.dir == "left" then
+                self.grid[current.y][current.x].block_left = false
+            elseif next.dir == "right" then
+                self.grid[current.y][current.x + 1].block_left = false
+            elseif next.dir == "down" then
+                self.grid[current.y + 1][current.x].block_top = false
+            end
+            visited[next.y][next.x] = true
+            table.insert(stack, { x = next.x, y = next.y })
+        else
+            table.remove(stack)
+        end
+    end
+end
+
+--- Print a textual representation of the maze for debugging
+function Maze:debug_print()
+    local w, h = self.width, self.height
+    -- draw initial top border
+    local line = ""
+    for x = 1, w do
+        line = line .. "+" .. (self.grid[1][x].block_top and "--" or "  ")
+    end
+    print(line .. "+")
+
+    for y = 1, h do
+        local middle = ""
+        local next_top = ""
+        for x = 1, w do
+            -- left wall of cell
+            middle = middle .. (self.grid[y][x].block_left and "|  " or "   ")
+            -- bottom wall uses next row's top flag when available
+            local bottom = true
+            if self.grid[y + 1] and self.grid[y + 1][x] then
+                bottom = self.grid[y + 1][x].block_top
+            end
+            next_top = next_top .. "+" .. (bottom and "--" or "  ")
+        end
+        print(middle .. "|")
+        print(next_top .. "+")
+    end
+end
+
+return Maze
+


### PR DESCRIPTION
## Summary
- add `debug_print()` to `maze.lua` for ASCII maze output
- call the new debug method in `main.script`
- document updates in `codexlog.md`

## Testing
- `luac -p main/main.script` *(fails: command not found)*
- `luac -p main/maze.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68733d6e0ac483249f8a7c35c65c65fb