### PR TITLE
Add disable-clear-wall checks to maze generation

### DIFF
--- a/codexlog.md
+++ b/codexlog.md
@@ -17,3 +17,7 @@
 - Added boundary assertions in `Maze.new` to ensure the maze dimensions are smaller than the base grid.
 - Implemented wall checking helpers `check_block_up`, `check_block_down`, `check_block_left`, `check_block_right` and `check_block` in `maze.lua`.
 
+## 2025-07-16
+- Added `CheckDisableClearWall` helper and integrated it into maze generation.
+- Maze generation now respects `disable_clear_wall` flags on grid cells.
+


### PR DESCRIPTION
## Summary
- extend maze generation to respect cells marked `disable_clear_wall`
- expose new `CheckDisableClearWall` helper
- log the update

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687437765a108324b5b706b49250bfde