### PR TITLE
Fix demo pattern wall clearing logic

### DIFF
--- a/codexlog.md
+++ b/codexlog.md
@@ -28,3 +28,5 @@
 ## 2025-07-18
 - Added assertion in `load_demo_pattern` to require at least a 4-cell margin around the pattern.
 
+## 2025-07-19
+- Reversed wall clearing logic in `load_demo_pattern` to clear walls when the corresponding bit is NOT set.

--- a/main/maze.lua
+++ b/main/maze.lua
@@ -251,10 +251,10 @@ function Maze:load_demo_pattern(pattern)
             if v then
                 local x = start_x + px - 1
                 local y = start_y + py - 1
-                if bit_enabled(v, 1) then self:clear_block_up(x, y) end
-                if bit_enabled(v, 2) then self:clear_block_right(x, y) end
-                if bit_enabled(v, 4) then self:clear_block_down(x, y) end
-                if bit_enabled(v, 8) then self:clear_block_left(x, y) end
+                if not bit_enabled(v, 1) then self:clear_block_up(x, y) end
+                if not bit_enabled(v, 2) then self:clear_block_right(x, y) end
+                if not bit_enabled(v, 4) then self:clear_block_down(x, y) end
+                if not bit_enabled(v, 8) then self:clear_block_left(x, y) end
             end
         end
     end


### PR DESCRIPTION
## Summary
- reverse the demo pattern wall clearing logic so bits indicate blocked walls
- document this change in `codexlog.md`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687443d9457c83248d2d2625d2153ab9