### PR TITLE
Implement missing maze helpers

### DIFF
--- a/codexlog.md
+++ b/codexlog.md
@@ -30,3 +30,7 @@
 
 ## 2025-07-19
 - Reversed wall clearing logic in `load_demo_pattern` to clear walls when the corresponding bit is NOT set.
+
+## 2025-07-20
+- Converted debug error print to an assertion in `Maze.generate`.
+- Implemented `set_disable_clear_wall` helper and updated call site in `load_demo_pattern`.

--- a/main/maze.lua
+++ b/main/maze.lua
@@ -93,10 +93,9 @@ function Maze:generate()
         local nbs = neighbors(current.x, current.y)
         if #nbs > 0 then
             local next = nbs[math.random(#nbs)]
-            -- TODO: change to assert
-            if self:CheckDisableClearWall(next.x, next.y) then
-                print("ERR:" .. next.x .. "," .. next.y .. " Something wrong")
-            end
+            assert(not self:CheckDisableClearWall(next.x, next.y),
+                string.format("Attempting to carve into disabled cell %d,%d",
+                    next.x, next.y))
             if not self:CheckDisableClearWall(current.x, current.y)
                 and not self:CheckDisableClearWall(next.x, next.y) then
                 -- remove wall between current and next
@@ -214,7 +213,15 @@ function Maze:check_block(x, y, dir)
     return nil
 end
 
--- TODO: function set_disable_clear_wall(x, y, flag)
+--- Set whether clearing walls is disabled for the given cell
+-- @param x number
+-- @param y number
+-- @param flag boolean True to disable clearing, false to enable
+function Maze:set_disable_clear_wall(x, y, flag)
+    if self.grid[y] and self.grid[y][x] then
+        self.grid[y][x].disable_clear_wall = flag and true or false
+    end
+end
 
 
 --- Print a textual representation of the maze for debugging
@@ -267,7 +274,7 @@ function Maze:load_demo_pattern(pattern)
             if v then
                 local x = start_x + px - 1
                 local y = start_y + py - 1
-                self::set_disable_clear_wall(x, y, true)
+                self:set_disable_clear_wall(x, y, true)
                 -- debug print demo pattern
                 print("dp: " .. x .."," ..y)
                 if not bit_enabled(v, 1) then self:clear_block_up(x, y) end


### PR DESCRIPTION
## Summary
- turn error prints into assertions in `Maze.generate`
- implement `set_disable_clear_wall` and use it in `load_demo_pattern`
- log the change in `codexlog.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687465133e788324bb6a5ce9351747f7