### PR TITLE
Compute maze center distances

### DIFF
--- a/codexlog.md
+++ b/codexlog.md
@@ -34,3 +34,9 @@
 ## 2025-07-20
 - Converted debug error print to an assertion in `Maze.generate`.
 - Implemented `set_disable_clear_wall` helper and updated call site in `load_demo_pattern`.
+
+## 2025-07-21
+- Added `calculate_center_distances` in `maze.lua` to compute minimum path
+  distances from the maze center.
+- Updated `main.script` to invoke the new function and print the resulting
+  distance grid for debugging.

--- a/main/main.script
+++ b/main/main.script
@@ -12,6 +12,15 @@ function init(self)
     self.maze:generate()
     print("Maze generated")
     self.maze:debug_print()
+    local dist = self.maze:calculate_center_distances()
+    for y = 1, #dist do
+        local line = ""
+        for x = 1, #dist[y] do
+            local v = dist[y][x]
+            line = line .. ((v == math.huge and "inf") or tostring(v)) .. " "
+        end
+        print(line)
+    end
 end
 
 function on_input(self, action_id, action)

--- a/main/maze.lua
+++ b/main/maze.lua
@@ -286,5 +286,52 @@ function Maze:load_demo_pattern(pattern)
     end
 end
 
+--- Calculate minimum path distances from maze center to all cells
+-- @return table Distance grid with math.huge for unreachable cells
+function Maze:calculate_center_distances()
+    local cx = math.floor((self.width + 1) / 2)
+    local cy = math.floor((self.height + 1) / 2)
+    local dist = {}
+    for y = 1, self.height do
+        dist[y] = {}
+        for x = 1, self.width do
+            dist[y][x] = math.huge
+        end
+    end
+
+    local queue = { { x = cx, y = cy } }
+    dist[cy][cx] = 0
+    local head = 1
+    while head <= #queue do
+        local node = queue[head]
+        head = head + 1
+        local d = dist[node.y][node.x]
+
+        -- explore neighbors that are not separated by walls
+        if node.y > 1 and not self:check_block_up(node.x, node.y) and
+           dist[node.y - 1][node.x] == math.huge then
+            dist[node.y - 1][node.x] = d + 1
+            queue[#queue + 1] = { x = node.x, y = node.y - 1 }
+        end
+        if node.y < self.height and not self:check_block_down(node.x, node.y) and
+           dist[node.y + 1][node.x] == math.huge then
+            dist[node.y + 1][node.x] = d + 1
+            queue[#queue + 1] = { x = node.x, y = node.y + 1 }
+        end
+        if node.x > 1 and not self:check_block_left(node.x, node.y) and
+           dist[node.y][node.x - 1] == math.huge then
+            dist[node.y][node.x - 1] = d + 1
+            queue[#queue + 1] = { x = node.x - 1, y = node.y }
+        end
+        if node.x < self.width and not self:check_block_right(node.x, node.y) and
+           dist[node.y][node.x + 1] == math.huge then
+            dist[node.y][node.x + 1] = d + 1
+            queue[#queue + 1] = { x = node.x + 1, y = node.y }
+        end
+    end
+
+    return dist
+end
+
 return Maze
 


### PR DESCRIPTION
## Summary
- calculate minimum path distance to maze center
- print the distance grid in `main.script`
- log the change

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6874681cb7508324958386b67c4ba39a