### PR TITLE
Move maze drawing to module

### DIFF
--- a/codexlog.md
+++ b/codexlog.md
@@ -34,3 +34,7 @@
 - Implemented `test_randomdice` in `main.script` to verify all `RandomDice` functions.
 - Added optional `seed` parameter to `Maze:generate` for deterministic runs.
 - Updated `main.script` to pass a seed via `os.time()`.
+- Added `Maze:draw` to render the maze using debug lines.
+- `main.script` now draws the maze each frame in `update()`.
+- Created `draw_maze.lua` module for maze rendering.
+- Removed `Maze:draw` and updated `main.script` to use the new module.

--- a/main/draw_maze.lua
+++ b/main/draw_maze.lua
@@ -1,0 +1,56 @@
+-- draw_maze.lua
+-- Utility to draw a Maze using debug lines
+
+local DrawMaze = {}
+
+--- Draw the maze using debug lines
+-- @param maze table Maze object
+-- @param cell_size number Size of each cell in pixels
+-- @param color vector4 Line color
+function DrawMaze.draw(maze, cell_size, color)
+    cell_size = cell_size or 32
+    color = color or vmath.vector4(1, 1, 1, 1)
+
+    local w, h = maze.width, maze.height
+    for y = 1, h do
+        for x = 1, w do
+            local ox = (x - 1) * cell_size
+            local oy = (y - 1) * cell_size
+
+            if maze:check_block_left(x, y) then
+                msg.post("@render:", "draw_line", {
+                    start_point = vmath.vector3(ox, oy, 0),
+                    end_point = vmath.vector3(ox, oy + cell_size, 0),
+                    color = color
+                })
+            end
+
+            if maze:check_block_up(x, y) then
+                msg.post("@render:", "draw_line", {
+                    start_point = vmath.vector3(ox, oy + cell_size, 0),
+                    end_point = vmath.vector3(ox + cell_size, oy + cell_size, 0),
+                    color = color
+                })
+            end
+
+            if x == w and maze:check_block_right(x, y) then
+                msg.post("@render:", "draw_line", {
+                    start_point = vmath.vector3(ox + cell_size, oy, 0),
+                    end_point = vmath.vector3(ox + cell_size, oy + cell_size, 0),
+                    color = color
+                })
+            end
+
+            if y == h and maze:check_block_down(x, y) then
+                msg.post("@render:", "draw_line", {
+                    start_point = vmath.vector3(ox, oy, 0),
+                    end_point = vmath.vector3(ox + cell_size, oy, 0),
+                    color = color
+                })
+            end
+        end
+    end
+end
+
+return DrawMaze
+

--- a/main/main.script
+++ b/main/main.script
@@ -1,6 +1,7 @@
 local Maze = require "main.maze"
 local DemoPattern = require "main.demo_pattern"
 local RandomDice = require "main.random_dice"
+local DrawMaze = require "main.draw_maze"
 
 -- Print the distance grid returned from Maze:calculate_center_distances
 local function print_distance_grid(dist)
@@ -80,4 +81,8 @@ function on_input(self, action_id, action)
     if action_id == hash("touch") and action.pressed then
         print("Touch!")
     end
+end
+
+function update(self, dt)
+    DrawMaze.draw(self.maze, 32)
 end

--- a/main/maze.lua
+++ b/main/maze.lua
@@ -266,7 +266,6 @@ function Maze:debug_print()
         print(next_top .. "+")
     end
 end
-
 --- Load a demo pattern into the maze and clear walls accordingly
 -- @param pattern table Pattern table returned from DemoPattern.load
 function Maze:load_demo_pattern(pattern)


### PR DESCRIPTION
## Summary
- extract maze drawing logic into new `draw_maze.lua`
- drop `Maze:draw` from `maze.lua`
- update `main.script` to use `DrawMaze.draw`
- log the refactor in `codexlog`

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6874b50699dc83249c4f493adb4419ec