### PR TITLE
Enable blending in custom render

### DIFF
--- a/codexlog.md
+++ b/codexlog.md
@@ -45,3 +45,5 @@
   `draw_line` and `draw_debug_text` messages.
 - Adjusted the custom render script to use the `sprite` predicate so the maze
   renders correctly.
+
+- Enabled blending state in custom render script before drawing sprites.

--- a/main/custom_render.render_script
+++ b/main/custom_render.render_script
@@ -66,6 +66,8 @@ function update(self, dt)
         [render.BUFFER_STENCIL_BIT] = 0
     })
 
+    render.enable_state(render.STATE_BLEND)
+
     apply_projection(self)
 
     render.draw(self.world_pred)


### PR DESCRIPTION
## Summary
- make the custom render script enable blending before drawing
- document the change in `codexlog.md`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68758dc624148324a36d83191cedefb4