### PR TITLE
Add maze debug draw module

### DIFF
--- a/codexlog.md
+++ b/codexlog.md
@@ -40,3 +40,7 @@
 ## 2025-07-15
 - Renamed `demo_pattern.lua` to `demo-pattern.lua`.
 - Moved `random_dice.lua` to `modules/random-dice.lua` and updated require paths.
+- Added `maze-draw.lua` module using `debug-draw` for maze rendering.
+- Updated `main.script` with an `update` function invoking the new drawer.
+- Renamed local variable `debugdraw` to `DebugDraw` in scripts.
+

--- a/main/main.script
+++ b/main/main.script
@@ -1,6 +1,8 @@
 local Maze = require "main.maze"
 local DemoPattern = require "main.demo-pattern"
 local RandomDice = require "modules.random-dice"
+local MazeDraw = require "main.maze-draw"
+local DebugDraw = require "modules.debug-draw"
 
 -- Print the distance grid returned from Maze:calculate_center_distances
 local function print_distance_grid(dist)
@@ -84,3 +86,9 @@ function on_input(self, action_id, action)
         print("Touch!")
     end
 end
+
+function update(self, dt)
+    MazeDraw.draw(self.maze, 32, 32, 16)
+    DebugDraw.text("Debug!", 100, 200, DebugDraw.COLORS.green)
+end
+

--- a/main/maze-draw.lua
+++ b/main/maze-draw.lua
@@ -1,0 +1,60 @@
+local DebugDraw = require "modules.debug-draw"
+
+local MazeDraw = {}
+
+ --- Draw a maze using DebugDraw lines
+-- @param maze Maze object
+-- @param ox origin x coordinate
+-- @param oy origin y coordinate
+-- @param size cell size in pixels
+-- @param color line color
+function MazeDraw.draw(maze, ox, oy, size, color)
+    ox = ox or 0
+    oy = oy or 0
+    size = size or 16
+    color = color or DebugDraw.COLORS.yellow
+
+    local h = maze.height
+    local w = maze.width
+    local grid = maze.grid
+
+    for y = 1, h do
+        for x = 1, w do
+            local cell = grid[y][x]
+            local x1 = ox + (x - 1) * size
+            local y1 = oy + (h - y) * size
+            local x2 = x1 + size
+            local y2 = y1 + size
+
+            if cell.block_top then
+                DebugDraw.line(x1, y2, x2, y2, color)
+            end
+            if cell.block_left then
+                DebugDraw.line(x1, y1, x1, y2, color)
+            end
+
+            if y == h then
+                local bottom = true
+                if grid[y + 1] and grid[y + 1][x] then
+                    bottom = grid[y + 1][x].block_top
+                end
+                if bottom then
+                    DebugDraw.line(x1, y1, x2, y1, color)
+                end
+            end
+
+            if x == w then
+                local right = true
+                if grid[y] and grid[y][x + 1] then
+                    right = grid[y][x + 1].block_left
+                end
+                if right then
+                    DebugDraw.line(x2, y1, x2, y2, color)
+                end
+            end
+        end
+    end
+end
+
+return MazeDraw
+


### PR DESCRIPTION
## Summary
- implement a `maze-draw.lua` helper that renders maze cells using debug-draw
- call this new module from `main.script` update
- document changes in codexlog
- rename local variable `DebugDraw` for clarity

## Testing
- `luajit -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68761dfbaddc8324a5d7193eda34f247