### PR TITLE
Ensure MazeDraw uses Y-down orientation

### DIFF
--- a/codexlog.md
+++ b/codexlog.md
@@ -43,4 +43,5 @@
 - Added `maze-draw.lua` module using `debug-draw` for maze rendering.
 - Updated `main.script` with an `update` function invoking the new drawer.
 - Renamed local variable `debugdraw` to `DebugDraw` in scripts.
+- Modified `maze-draw.lua` to keep maze coordinates in Y-down orientation.
 

--- a/main/maze-draw.lua
+++ b/main/maze-draw.lua
@@ -22,7 +22,8 @@ function MazeDraw.draw(maze, ox, oy, size, color)
         for x = 1, w do
             local cell = grid[y][x]
             local x1 = ox + (x - 1) * size
-            local y1 = oy + (h - y) * size
+            -- Keep the maze in Y-down orientation without flipping
+            local y1 = oy + (y - 1) * size
             local x2 = x1 + size
             local y2 = y1 + size
 


### PR DESCRIPTION
## Summary
- maintain Y-down coordinate system in `maze-draw.lua`
- log the change

## Testing
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687634a2ceec8324ae8ac2475e09aa73